### PR TITLE
feature/quick-rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Electron-Rebuild
 
-This executable rebuilds native io.js modules against the version of io.js
-that your Electron project is using. This allows you to use native io.js
+This executable rebuilds node & iojs modules against the version of io.js
+that your Electron project is using. This allows you to use native node & io.js
 modules in Electron apps without your system version of io.js matching exactly
 (which is often not the case, and sometimes not even possible).
 
@@ -16,8 +16,21 @@ npm install --save-dev electron-rebuild
 Then, whenever you install a new npm package, rerun electron-rebuild:
 
 ```sh
-./node_modules/.bin/electron-rebuild
+./node_modules/.bin/electron-rebuild # [options]
 ```
+
+#### options
+See [src/cli.js](src/cli.js) to see the available cli options to configure your rebuild.
+
+##### quick builds `quick`
+The `-q` flag will maintain a list of what packages have been built against a
+target version, and only rebuild those modules that are not currently built
+against it.
+
+##### ignore modules to rebuild `ignore`
+When using this module programatically, you can add `ignore: ['array', 'of', 'package', names]`
+when calling `rebuildNativeModules` to _not_ rebuild those modules.  This feature
+_must be used in conjuction with quick mode_, or is ignored.
 
 ### How can I integrate this into Grunt / Gulp / Whatever?
 
@@ -27,10 +40,10 @@ build process. It has two main methods:
 ```js
 import { installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules } from 'electron-rebuild';
 
-// Public: Determines whether we need to rebuild native modules (i.e. if they're 
+// Public: Determines whether we need to rebuild native modules (i.e. if they're
 // already compiled for the right version of Electron, no need to rebuild them!)
 //
-// pathToElectronExecutable - Path to the electron executable that we'll use 
+// pathToElectronExecutable - Path to the electron executable that we'll use
 //                            to determine NODE_MODULE_VERSION
 // explicitNodeVersion (optional) - If given, use this instead of probing Electron
 //
@@ -43,7 +56,7 @@ let shouldBuild = shouldRebuildNativeModules('/path/to/Electron');
 // nodeVersion - the version of Electron to download headers for
 // nodeDistUrl (optional) - the URL to download the distribution from
 // headersDir (optional) - where to put the headers
-// arch (optional) - The architecture to build against (for building 32-bit apps 
+// arch (optional) - The architecture to build against (for building 32-bit apps
 //                   on 64-bit Windows for example)
 //
 // Returns a Promise indicating whether the operation succeeded or not
@@ -64,7 +77,7 @@ A full build process might look something like:
 shouldRebuildNativeModules(pathToElectron)
   .then((shouldBuild) => {
     if (!shouldBuild) return true;
-    
+
     return installNodeHeaders('v0.27.2')
       .then(() => rebuildNativeModules('v0.27.2', './node_modules'));
   })

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
     "electron-prebuilt": "^0.31.2",
-    "mocha": "^2.3.0"
+    "mocha": "^2.3.0",
+    "mock-npm-install": "^1.0.4"
   }
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,100 @@
+import promisify from './promisify';
+import path from 'path';
+import os from 'os';
+import { md5 } from './hash';
+
+const fs = promisify(require('fs'));
+
+/**
+ * Returns the path to the quick-build cache for a given nodeModules folder
+ * @param {string} nodeModulesPath
+ * @return {string} /path/to/quick-build-cache
+ */
+export const getPackageCachePath = (nodeModulesPath) => {
+    const pathHash = md5(path.resolve(nodeModulesPath));
+    return path.resolve(os.tmpdir(), 'electron-rebuild-cache-' + pathHash);
+};
+
+/**
+ * Returns the quick-build cache
+ * @param {string} nodeModulesPath
+ * @return {Promise} resolves => quick-build cache
+ */
+export async function getCachedBuildVersions(nodeModulesPath) {
+      if (!nodeModulesPath) {
+          throw new ReferenceError('nodeModulesPath missing');
+      }
+      const cachePath = getPackageCachePath(nodeModulesPath);
+      try {
+          return await fs.readFile(cachePath, 'utf8').then(cache => JSON.parse(cache));
+      } catch(err) {
+        if (err && err.code === 'ENOENT') {
+          // no existing cache. upsert it to disk in a hot moment
+        } else {
+          console.error(err.message);
+          throw err;
+        }
+      }
+      try {
+          return await upsertCache(nodeModulesPath);
+      } catch(err) {
+          console.error('unable to create electron-rebuild cache: ' + err.message);
+          throw err;
+      }
+}
+
+/**
+ * Filters a list of file names to include only those that point to folders
+ * within the provided src folder
+ * @param {array} fnames list of file or folder names
+ * @param {string} nodeModulesPath
+ * @return {Promise} resolves => ['names', 'of', 'folders']
+ */
+async function filterFsFolders(fnames, nodeModulesPath) {
+  try {
+    let stats = fnames.map(file => fs.stat(path.join(nodeModulesPath, file)));
+    stats = await Promise.all(stats);
+    return stats.map((stat, ndx) => {
+        if (stat.isDirectory()) {
+            return {
+                package: fnames[ndx],
+                stat
+            };
+        }
+    }).filter(f => f);
+  } catch(err) {
+    console.error(`unable to read folders in node_modules directory: ${nodeModulesPath}`);
+    throw err;
+  }
+}
+
+/**
+ * Returns all of the folders in the provided node_modules,
+ * and `stat` objects for each
+ * @param {string} nodeModulesPath
+ * @return {Promise} resolves => [{ name: 'folder-name', stat: Stat}]
+ */
+export async function getInstalledModules(nodeModulesPath) {
+    const nodeModules = await fs.readdir(nodeModulesPath);
+    const filesOrFolders = nodeModules.filter(name => !name.match(/^\./)); // ignore hidden
+    return filterFsFolders(filesOrFolders, nodeModulesPath);
+}
+
+/**
+ * Creates or updates the quick-rebuild cache
+ * @param {string} nodeModulesPath
+ * @param {array=} cache values [{ package: ..., nodeVersion: ..., ctime: ... }]
+ * @return {Promise} resolves => cache
+ */
+export async function upsertCache(nodeModulesPath, cache=[]) {
+    const verb = cache.length ? 'updated' : 'built';
+    const cachePath = getPackageCachePath(nodeModulesPath);
+    try {
+        await fs.writeFile(cachePath, JSON.stringify(cache));
+        console.log(`electron-rebuild: cache ${verb} ${cachePath}`);
+        return cache;
+    } catch(err) {
+        console.error('unable to write electron-rebuild cache file');
+        throw err;
+    }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,8 @@ const argv = require('yargs')
   .help('h')
   .alias('h', 'help')
   .describe('v', 'The version of Electron to build against')
+  .alias('q', 'quick')
+  .describe('q', 'Enable quick rebuilds')
   .alias('v', 'version')
   .describe('n', 'The NODE_MODULE_VERSION to compare against (process.versions.modules)')
   .alias('n', 'node-module-version')
@@ -82,7 +84,14 @@ shouldRebuildPromise
     if (!x) process.exit(0);
 
     return installNodeHeaders(argv.v, null, null, argv.a)
-      .then(() => rebuildNativeModules(argv.v, argv.m, null, argv.a))
+      .then(() => {
+          return rebuildNativeModules({
+              nodeVersion: argv.v,
+              nodeModulesPath: argv.m,
+              arch: argv.a,
+              quick: argv.q
+          });
+      })
       .then(() => process.exit(0));
   })
   .catch((e) => {

--- a/src/hash.js
+++ b/src/hash.js
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+
+/**
+ * md5 hash an input string
+ * @return {string}
+ */
+export const md5 = function(str) {
+    return crypto.createHash('md5').update(str).digest("hex");
+}

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import childProcess from 'child_process';
 import spawn from './spawn';
 import promisify from './promisify';
+import os from 'os';
+import { getCachedBuildVersions, getInstalledModules, upsertCache } from './cache';
 
 const fs = promisify(require('fs'));
 
@@ -13,7 +15,7 @@ const getHeadersRootDirForVersion = (version) => {
 const checkForInstalledHeaders = async function(nodeVersion, headersDir) {
   const canary = path.join(headersDir, '.node-gyp', nodeVersion, 'common.gypi');
   let stat = await fs.stat(canary);
-  
+
   if (!stat) throw new Error("Canary file 'common.gypi' doesn't exist");
   return true;
 };
@@ -23,18 +25,18 @@ const spawnWithHeadersDir = async (cmd, args, headersDir, cwd) => {
   if (process.platform === 'win32')  {
     env.USERPROFILE = env.HOME;
   }
-  
+
   try {
     let opts = {env};
-    if (cwd) { 
+    if (cwd) {
       opts.cwd = cwd;
     }
-    
+
     return await spawn({cmd, args, opts});
   } catch (e) {
     if (e.stdout) console.log(e.stdout);
     if (e.stderr) console.log(e.stderr);
-    
+
     throw e;
   }
 };
@@ -42,14 +44,14 @@ const spawnWithHeadersDir = async (cmd, args, headersDir, cwd) => {
 const getElectronModuleVersion = async (pathToElectronExecutable) => {
   let args = [ '-e', 'console.log(process.versions.modules)' ]
   let env = { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1' };
-  
+
   let result = await spawn({cmd: pathToElectronExecutable, args, opts: {env}});
   let versionAsString = (result.stdout + result.stderr).replace(/\n/g, '');
-  
+
   if (!versionAsString.match(/^\d+$/)) {
     throw new Error(`Failed to check Electron's module version number: ${versionAsString}`);
   }
-  
+
   return toString(versionAsString);
 }
 
@@ -61,7 +63,7 @@ export async function installNodeHeaders(nodeVersion, nodeDistUrl=null, headersD
     await checkForInstalledHeaders(nodeVersion, headersDir);
     return;
   } catch (e) { }
-  
+
   let cmd = 'node';
   let args = [
     require.resolve('npm/node_modules/node-gyp/bin/node-gyp'), 'install',
@@ -69,12 +71,12 @@ export async function installNodeHeaders(nodeVersion, nodeDistUrl=null, headersD
     `--arch=${arch || process.arch}`,
     `--dist-url=${distUrl}`
   ];
-  
+
   await spawnWithHeadersDir(cmd, args, headersDir);
 }
 
 export async function shouldRebuildNativeModules(pathToElectronExecutable, explicitNodeVersion=null) {
-  // Try to load our canary module - if it fails, we know that it's built 
+  // Try to load our canary module - if it fails, we know that it's built
   // against a different node module than ours, so we're good
   //
   // NB: Apparently on OS X, this not only fails to be required, it segfaults
@@ -82,36 +84,110 @@ export async function shouldRebuildNativeModules(pathToElectronExecutable, expli
   try {
     let args = ['-e', 'require("nslog")']
     await spawn({cmd: process.execPath, args});
-    
+
     require('nslog');
   } catch (e) {
     return true;
   }
-  
+
   // We need to check the native module version of Electron vs ours - if they
   // happen to be the same, we're good
-  let version = explicitNodeVersion || 
+  let version = explicitNodeVersion ||
     (await getElectronModuleVersion(pathToElectronExecutable));
-  
-  if (version === process.versions.modules) { 
+
+  if (version === process.versions.modules) {
     return false;
   }
-  
+
   // If we loaded nslog and the versions don't match, we've got to rebuild
   return true;
 }
 
-export async function rebuildNativeModules(nodeVersion, nodeModulesPath, headersDir=null, arch=null) {
-  headersDir = headersDir || getHeadersRootDirForVersion(nodeVersion);
-  await checkForInstalledHeaders(nodeVersion, headersDir);
-  
+export async function rebuildNativeModules(cfg) {
+  let opts = _.isString(cfg) ? { nodeVersion: cfg } : _.assign({}, cfg);
+  opts = _.defaults(opts, { headersDir: null, arch: null });
+  opts.headersDir = opts.headersDir || getHeadersRootDirForVersion(opts.nodeVersion);
+  await checkForInstalledHeaders(opts.nodeVersion, opts.headersDir);
+
+  if (opts.quick) {
+      return rebuildNativeModulesQuick(opts);
+  }
+  return rebuildNativeModulesDefault(opts);
+}
+
+/**
+ * Rebuilds modules one-by-one, conditionally, if they are not already built
+ * per the cache table
+ * @param {object} opts cli-ops
+ * @return {Promise}
+ */
+export async function rebuildNativeModulesQuick(opts) {
+  const { nodeModulesPath } = opts;
+  const [ installedPkgs, builtPkgs ] = await Promise.all([
+      getInstalledModules(nodeModulesPath),
+      getCachedBuildVersions(nodeModulesPath)
+  ]);
+  let toBuild = installedPkgs.filter(pkg => {
+    // test if installed pkg has matching built pkg, per the cache.
+    // include pkg in the `toBuild` list if no matching built module, or if
+    // the module folder has changed since last build
+    return !builtPkgs.some(builtPkg => {
+        return (
+            builtPkg.package === pkg.package &&
+            builtPkg.nodeVersion === opts.nodeVersion &&
+            builtPkg.ctime === pkg.stat.ctime.toISOString()
+        );
+    });
+  });
+
+  if (opts.ignore) {
+      const ignore = Array.isArray(opts.ignore) ? opts.ignore : [opts.ignore];
+      toBuild = toBuild.filter(pkg => !_.contains(ignore, pkg.package));
+  }
+
+  toBuild = toBuild.map(pkg => {
+      return {
+          package: pkg.package,
+          nodeVersion: opts.nodeVersion,
+          ctime: pkg.stat.ctime.toISOString()
+      };
+  });
+  if (!toBuild.length) {
+      console.log(`electron-rebuild: all builds up-to-date`);
+      return Promise.resolve();
+  }
+  try {
+    // sequentially build each package
+    const total = toBuild.length;
+    await toBuild.reduce((prev, bld, ndx)=> {
+       const buildNdx = ndx + 1;
+       const bOps = Object.assign({}, bld, opts);
+       return prev.then(last => {
+          console.log(`electron-rebuild: ${buildNdx}/${total}, ${bld.package}`);
+          return rebuildNativeModulesDefault(bOps);
+      }).catch(function(err) {
+          console.log(err);
+          throw err;
+      });
+    }, Promise.resolve());
+    console.log('electron-rebuild: updating build cache');
+    return await upsertCache(nodeModulesPath, toBuild);
+  } catch(err) {
+    console.error('unable to build target modules or update cache');
+    throw err;
+  }
+}
+
+export async function rebuildNativeModulesDefault(opts) {
+  const { headersDir, nodeModulesPath } = opts;
   let cmd = 'node';
   let args = [
-    require.resolve('npm/bin/npm-cli'), 'rebuild', 
+    require.resolve('npm/bin/npm-cli'), 'rebuild',
+    opts.package ? opts.package : null,
     '--runtime=electron',
-    `--target=${nodeVersion}`, 
-    `--arch=${arch || process.arch}`
-  ];
-  
-  await spawnWithHeadersDir(cmd, args, headersDir, nodeModulesPath);
+    `--target=${opts.nodeVersion}`,
+    `--arch=${opts.arch || process.arch}`
+   ].filter(arg => arg);
+
+  return await spawnWithHeadersDir(cmd, args, headersDir, nodeModulesPath);
 }

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,134 @@
+import _ from './support';
+import fs from 'fs';
+import path from 'path';
+import pkgMock from 'mock-npm-install';
+import promisify from '../lib/promisify';
+import { getPackageCachePath, getCachedBuildVersions } from '../lib/cache.js';
+import { installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules } from '../lib/main.js';
+import { mkdir, rmdir } from './utils/fileio.js';
+import * as main from '../lib/main.js';
+import spawn from '../lib/spawn.js';
+
+const rimraf = promisify(require('rimraf'));
+const cp = promisify(require('ncp').ncp);
+
+const targetHeaderDir = path.join(__dirname, 'testheaders');
+const targetModulesDir = path.join(__dirname, 'node_modules');
+const mockPkgDir = path.resolve(targetModulesDir, 'build-test-1');
+const mockPkgBuiltFile = path.resolve(mockPkgDir, 'build-test-file');
+const cachePath = getPackageCachePath(targetModulesDir);
+const moduleVersionToTest = '0.31.2';
+
+const assertFileNotPresent = function(path) {
+    const stat = fs.statSync(path);
+    if (stat instanceof Error) {
+        throw stat;
+    }
+}
+
+const installMockPackage = function() {
+    return pkgMock.install({
+        nodeModulesDir: targetModulesDir,
+        package: {
+            name: 'build-test-1',
+            scripts: { postinstall: `touch ${mockPkgBuiltFile}` } // npm build exec's
+        }
+    });
+};
+
+describe('quick mode', function() {
+  this.timeout(30*1000);
+
+    describe('rebuildNativeModules quickly with caching', function() {
+        it(`should rebuild with cached versions`, async () => {
+            try {
+                await rmdir(targetModulesDir);
+                await rmdir(targetHeaderDir);
+                await mkdir(targetHeaderDir);
+                await mkdir(targetModulesDir);
+                let mockPkg1 = installMockPackage();
+
+                await installNodeHeaders(moduleVersionToTest, null, targetHeaderDir);
+                await main.rebuildNativeModules({
+                    nodeVersion: moduleVersionToTest,
+                    nodeModulesPath: targetModulesDir,
+                    headersDir: targetHeaderDir,
+                    quick: true
+                });
+
+                // assert that mock package build process run successfully
+                expect(fs.statSync(`${mockPkgBuiltFile}`)).to.be.ok;
+
+                // assert that rebuild-cache built successfully
+                expect(fs.statSync(cachePath)).to.be.ok;
+                const cachedContent = await getCachedBuildVersions(targetModulesDir);
+                cachedContent[0].nodeVersion.should.equal(moduleVersionToTest);
+
+                // assert that rebuild run again does not rebuild module after cached
+                fs.unlinkSync(mockPkgBuiltFile);
+                await main.rebuildNativeModules({
+                    nodeVersion: moduleVersionToTest,
+                    nodeModulesPath: targetModulesDir,
+                    headersDir: targetHeaderDir,
+                    quick: true
+                });
+                try {
+                    assertFileNotPresent(mockPkgBuiltFile);
+                } catch(err) {
+                    if (err.code !== 'ENOENT') {
+                        throw new Error('file was built when it was not supposed to');
+                    }
+                }
+
+                // assert that module updates after node_modules/some-package folder touched
+                const ctime_oldfolder = (fs.statSync(mockPkgBuiltFile)).ctime.toISOString();
+                pkgMock.remove({ nodeModulesDir: targetModulesDir, name: mockPkg1.name });
+                await (async () => {
+                    // delay so ctime.toISOString varies observably
+                    return new Promise((res) => { setTimeout(() => { res(); }, 2000); })
+                })();
+                mockPkg1 = installMockPackage();
+                await main.rebuildNativeModules({
+                    nodeVersion: moduleVersionToTest,
+                    nodeModulesPath: targetModulesDir,
+                    headersDir: targetHeaderDir,
+                    quick: true
+                });
+                const ctime_newfolder = (fs.statSync(mockPkgBuiltFile)).ctime.toISOString();
+                expect(ctime_oldfolder !== ctime_newfolder).to.be.ok;; // pkg rebuilt!
+
+                await rmdir(targetModulesDir);
+                await rmdir(targetHeaderDir);
+            } catch(err) {
+                return Promise.reject();
+            }
+        });
+
+        it(`should ignore rebuilds on ignore request`, async () => {
+          await rmdir(targetModulesDir);
+          await rmdir(targetHeaderDir);
+          await mkdir(targetHeaderDir);
+          await mkdir(targetModulesDir);
+          let mockPkg1 = installMockPackage();
+
+          await installNodeHeaders(moduleVersionToTest, null, targetHeaderDir);
+          await main.rebuildNativeModules({
+              nodeVersion: moduleVersionToTest,
+              nodeModulesPath: targetModulesDir,
+              headersDir: targetHeaderDir,
+              quick: true,
+              ignore: 'build-test-1'
+          });
+
+          // assert that mock package build didn't build ignored package,
+          // so built file should not exist
+          try {
+              fs.statSync(mockPkgBuiltFile);
+          } catch (err) {
+              if (err.code !== 'ENOENT') {
+                  throw new Error('file was built when it was not supposed to');
+              }
+          }
+        });
+    });
+});

--- a/test/main.js
+++ b/test/main.js
@@ -1,45 +1,34 @@
 import _ from './support';
 import path from 'path';
+import pkgMock from 'mock-npm-install';
 import promisify from '../lib/promisify';
+import { mkdir, rmdir } from './utils/fileio.js';
 const fs = promisify(require('fs'));
-const rimraf = promisify(require('rimraf'));
 const cp = promisify(require('ncp').ncp);
 
 import {installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules} from '../lib/main.js';
 
 describe('installNodeHeaders', function() {
   this.timeout(30*1000);
-  
+
   it('installs node headers for 0.25.2', async () => {
     let targetHeaderDir = path.join(__dirname, 'testheaders');
+    await rmdir(targetHeaderDir);
+    await mkdir(targetHeaderDir);
 
-    try {
-      if (await fs.stat(targetHeaderDir)) {
-        await rimraf(targetHeaderDir);
-      }  
-    } catch (e) { }
-    
-    await fs.mkdir(targetHeaderDir);
-    
     await installNodeHeaders('0.25.2', null, targetHeaderDir);
     let canary = await fs.stat(path.join(targetHeaderDir, '.node-gyp', '0.25.2', 'common.gypi'));
     expect(canary).to.be.ok
 
-    await rimraf(targetHeaderDir);
+    await rmdir(targetHeaderDir);
   });
 
   it('check for installed headers for 0.27.2', async () => {
     let targetHeaderDir = path.join(__dirname, 'testheaders');
-
-    try {
-      if (await fs.stat(targetHeaderDir)) {
-        await rimraf(targetHeaderDir);
-      }
-    } catch (e) { }
-
-    await fs.mkdir(targetHeaderDir);
-    await fs.mkdir(path.join(targetHeaderDir, '.node-gyp'));
-    await fs.mkdir(path.join(targetHeaderDir, '.node-gyp', '0.27.2'));
+    await rmdir(targetHeaderDir);
+    await mkdir(targetHeaderDir);
+    await mkdir(path.join(targetHeaderDir, '.node-gyp'));
+    await mkdir(path.join(targetHeaderDir, '.node-gyp', '0.27.2'));
     const canary = path.join(targetHeaderDir, '.node-gyp', '0.27.2', 'common.gypi');
     await fs.close(await fs.open(canary, 'w'));
 
@@ -53,7 +42,7 @@ describe('installNodeHeaders', function() {
     }
     expect(shouldDie).to.equal(false);
 
-    await rimraf(targetHeaderDir);
+    await rmdir(targetHeaderDir);
   });
 });
 
@@ -62,55 +51,61 @@ describe('rebuildNativeModules', function() {
 
   const moduleVersionsToTest = ['0.22.0', '0.31.2'];
 
-  for(let nativeModuleVersionToBuildAgainst of moduleVersionsToTest) {
-    it(`Rebuilds native modules against ${nativeModuleVersionToBuildAgainst}`, async () => {
-      const targetHeaderDir = path.join(__dirname, 'testheaders');
-      const targetModulesDir = path.join(__dirname, 'node_modules');
-      
+  for(let version of moduleVersionsToTest) {
+    it(`Rebuilds native modules against ${version}`, async () => {
       try {
-        if (await fs.stat(targetHeaderDir)) {
-          await rimraf(targetHeaderDir);
-        }  
-      } catch (e) { }
-      
-      await fs.mkdir(targetHeaderDir);
-      
-      try {
-        if (await fs.stat(targetModulesDir)) {
-          await rimraf(targetModulesDir);
-        }
-      } catch (e) { }
-      
-      await installNodeHeaders(nativeModuleVersionToBuildAgainst, null, targetHeaderDir);
-      let canary = await fs.stat(path.join(targetHeaderDir, '.node-gyp', nativeModuleVersionToBuildAgainst, 'common.gypi'));
-      expect(canary).to.be.ok
-      
-      // Copy our own node_modules folder to a fixture so we don't trash it
-      await cp(path.resolve(__dirname, '..', 'node_modules'), targetModulesDir);
-      
-      canary = await fs.stat(path.join(targetModulesDir, 'babel'));
-      expect(canary).to.be.ok;
-      
-      await rebuildNativeModules(nativeModuleVersionToBuildAgainst, path.resolve(targetModulesDir, '..'), targetHeaderDir);
-      await rimraf(targetModulesDir);
-      await rimraf(targetHeaderDir);
+          const targetHeaderDir = path.join(__dirname, 'testheaders');
+          const targetModulesDir = path.join(__dirname, 'node_modules');
+          await rmdir(targetHeaderDir);
+          await mkdir(targetHeaderDir);
+          await rmdir(targetModulesDir);
+          await mkdir(targetModulesDir);
+          await installNodeHeaders(version, null, targetHeaderDir);
+          let canary = await fs.stat(path.join(targetHeaderDir, '.node-gyp', version, 'common.gypi'));
+          expect(canary).to.be.ok
+
+          rmdir('mock-pkg-1');
+          const mockPkg = pkgMock.install({
+              nodeModulesDir: targetModulesDir,
+              package: {
+                  name: 'mock-pkg-1',
+                  scripts: { postinstall: `touch ${version}`} // npm build will run postinstall
+              }
+          });
+
+          await rebuildNativeModules({
+              nodeVersion: version,
+              nodeModulesPath: targetModulesDir,
+              headersDir: targetHeaderDir
+          });
+
+
+          let buildTestFile = await fs.stat(path.resolve(targetModulesDir, mockPkg.name, `${version}`));
+          expect(buildTestFile).to.be.ok
+
+          // clean up
+          await rmdir(targetModulesDir);
+          await rmdir(targetHeaderDir);
+      } catch(err) {
+          console.error(err.message);
+          console.log(err);
+      }
     });
   }
 });
 
 describe('shouldRebuildNativeModules', function() {
   this.timeout(60*1000);
-  
+
   it('should always return true most of the time maybe', async () => {
     // Use the electron-prebuilt path
     let pathDotText = path.join(
       path.dirname(require.resolve('electron-prebuilt')),
       'path.txt');
-      
+
     let electronPath = await fs.readFile(pathDotText, 'utf8');
-    //console.log(`Electron Path: ${electronPath}`)
     let result = await shouldRebuildNativeModules(electronPath);
-    
+
     expect(result).to.be.ok;
   });
-})
+});

--- a/test/utils/fileio.js
+++ b/test/utils/fileio.js
@@ -1,0 +1,24 @@
+import promisify from '../../lib/promisify';
+const fs = promisify(require('fs'));
+const rimraf = promisify(require('rimraf'));
+
+export async function rmdir(dir) {
+    try {
+        if (await fs.stat(dir)) {
+            await rimraf(dir);
+        }
+    } catch (err) {
+        // silent fail is OK
+    }
+};
+
+export async function mkdir(dir) {
+    await fs.mkdir(dir);
+    try {
+        if (await fs.stat(targetModulesDir)) {
+            await rimraf(targetModulesDir);
+        }
+    } catch (err) {
+        // silent fail is OK
+    }
+};


### PR DESCRIPTION
# problem statement
- rebuilds are slow for large projects
- rebuilds re-build content that doesn't _need to be rebuilt_

# solution
- maintain a cache of modules that have been built
- rebuild only those modules that have not been built since last `electron-rebuild`
    - because we cannot control users from doing something like `rm -rf node_modules/some_module`, our cache is at risk of being invalided.  Therefore, cache `node_modules/some_folder`'s  `stat.ctime`, and assert that the cached `ctime` === the folders current `ctime`.  If they're not ===, fallback safely by just rebuilding `some_module`