### PR TITLE
Allow different npm commands via -c flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -96,7 +96,7 @@ shouldRebuildPromise
     if (!x) process.exit(0);
 
     return installNodeHeaders(argv.v, null, null, argv.a)
-      .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, argv.c, null, argv.a))
+      .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, null, argv.a, argv.c))
       .then(() => process.exit(0));
   })
   .catch((e) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,11 +22,17 @@ const argv = require('yargs')
   .alias('w', 'which-module')
   .describe('e', 'The path to electron-prebuilt')
   .alias('e', 'electron-prebuilt-dir')
+  .describe('c', 'The npm command to run')
+  .alias('c', 'command')
   .epilog('Copyright 2015')
   .argv;
 
 if (!argv.e) {
   argv.e = path.join(__dirname, '..', '..', 'electron-prebuilt');
+}
+
+if (!argv.c) {
+  argv.c = 'rebuild';
 }
 
 if (!argv.v) {
@@ -79,6 +85,8 @@ if (!electronPath && !nodeModuleVersion) {
   shouldRebuildPromise = Promise.resolve(true);
 } else if (argv.f) {
   shouldRebuildPromise = Promise.resolve(true);
+} else if (argv.c == 'install') {
+  shouldRebuildPromise = Promise.resolve(true);
 } else {
   shouldRebuildPromise = shouldRebuildNativeModules(electronPath, nodeModuleVersion);
 }
@@ -88,7 +96,7 @@ shouldRebuildPromise
     if (!x) process.exit(0);
 
     return installNodeHeaders(argv.v, null, null, argv.a)
-      .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, null, argv.a))
+      .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, argv.c, null, argv.a))
       .then(() => process.exit(0));
   })
   .catch((e) => {

--- a/src/main.js
+++ b/src/main.js
@@ -101,14 +101,14 @@ export async function shouldRebuildNativeModules(pathToElectronExecutable, expli
   return true;
 }
 
-export async function rebuildNativeModules(nodeVersion, nodeModulesPath, whichModule=null, headersDir=null, arch=null) {
+export async function rebuildNativeModules(nodeVersion, nodeModulesPath, whichModule=null, command='rebuild', headersDir=null, arch=null) {
   headersDir = headersDir || getHeadersRootDirForVersion(nodeVersion);
   await checkForInstalledHeaders(nodeVersion, headersDir);
 
   let cmd = 'node';
   let args = [
     require.resolve('npm/bin/npm-cli'),
-    'rebuild'
+    command
   ];
 
   if (whichModule) {

--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,7 @@ export async function shouldRebuildNativeModules(pathToElectronExecutable, expli
   return true;
 }
 
-export async function rebuildNativeModules(nodeVersion, nodeModulesPath, whichModule=null, command='rebuild', headersDir=null, arch=null) {
+export async function rebuildNativeModules(nodeVersion, nodeModulesPath, whichModule=null, headersDir=null, arch=null, command='rebuild') {
   headersDir = headersDir || getHeadersRootDirForVersion(nodeVersion);
   await checkForInstalledHeaders(nodeVersion, headersDir);
 


### PR DESCRIPTION
Added a flag for -c to allow you to pass different commands (i.e. install) to npm via the module. Still defaults to `rebuild`