### PR TITLE
Workaround for node-pre-gyp's lack of electron runtime detection (and a little bugfixing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/paulcbetts/electron-rebuild",
   "dependencies": {
     "babel-runtime": "^5.8.20",
+    "glob": "^6.0.3",
     "lodash": "^3.10.1",
     "ncp": "^2.0.0",
     "npm": "^2.14.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,7 +53,7 @@ let nodeModuleVersion = null;
 if (!argv.n) {
   try {
     let pathDotText = path.join(argv.e, 'path.txt');
-    electronPath = path.join(argv.e, fs.readFileSync(pathDotText, 'utf8'));
+    electronPath = path.resolve(argv.e, fs.readFileSync(pathDotText, 'utf8'));
   } catch (e) {
     console.error("Couldn't find electron-prebuilt and no --node-module-version parameter set, always rebuilding");
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -87,16 +87,13 @@ if (!electronPath && !nodeModuleVersion) {
 }
 
 shouldRebuildPromise
-  .then(async (x) => {
-    var beforeRebuild;
-
+  .then(x => {
     if (!x) process.exit(0);
-    if (argv.p) return await preGypFixSetup(argv.m);
   })
   .then((x, beforeRebuild) => {
     return installNodeHeaders(argv.v, null, null, argv.a)
       .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, null, argv.a))
-      .then(() => preGypFixRun(argv.m))
+      .then(() => preGypFixRun(argv.m, argv.p, electronPath, nodeModuleVersion))
       .then(() => process.exit(0));
   })
   .catch((e) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import {installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules} from './main.js';
+import { preGypFixSetup, preGypFixRun } from './node-pre-gyp-fix.js'
 import path from 'path';
 import fs from 'fs';
 
@@ -22,6 +23,8 @@ const argv = require('yargs')
   .alias('w', 'which-module')
   .describe('e', 'The path to electron-prebuilt')
   .alias('e', 'electron-prebuilt-dir')
+  .describe('p', 'Enable the ugly (and hopefully not needed soon enough) node-pre-gyp path fixer')
+  .alias('p', 'pre-gyp-fix')
   .epilog('Copyright 2015')
   .argv;
 
@@ -84,11 +87,16 @@ if (!electronPath && !nodeModuleVersion) {
 }
 
 shouldRebuildPromise
-  .then(x => {
-    if (!x) process.exit(0);
+  .then(async (x) => {
+    var beforeRebuild;
 
+    if (!x) process.exit(0);
+    if (argv.p) return await preGypFixSetup(argv.m);
+  })
+  .then((x, beforeRebuild) => {
     return installNodeHeaders(argv.v, null, null, argv.a)
       .then(() => rebuildNativeModules(argv.v, argv.m, argv.w, null, argv.a))
+      .then(() => preGypFixRun(argv.m))
       .then(() => process.exit(0));
   })
   .catch((e) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,7 +53,7 @@ let nodeModuleVersion = null;
 if (!argv.n) {
   try {
     let pathDotText = path.join(argv.e, 'path.txt');
-    electronPath = fs.readFileSync(pathDotText, 'utf8');
+    electronPath = path.join(argv.e, fs.readFileSync(pathDotText, 'utf8'));
   } catch (e) {
     console.error("Couldn't find electron-prebuilt and no --node-module-version parameter set, always rebuilding");
   }

--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,7 @@ const spawnWithHeadersDir = async (cmd, args, headersDir, cwd) => {
   }
 };
 
-const getElectronModuleVersion = async (pathToElectronExecutable) => {
+export async function getElectronModuleVersion(pathToElectronExecutable) {
   let args = [ '-e', 'console.log(process.versions.modules)' ]
   let env = { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1' };
 

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ const getElectronModuleVersion = async (pathToElectronExecutable) => {
     throw new Error(`Failed to check Electron's module version number: ${versionAsString}`);
   }
 
-  return toString(versionAsString);
+  return versionAsString;
 }
 
 export async function installNodeHeaders(nodeVersion, nodeDistUrl=null, headersDir=null, arch=null) {

--- a/src/node-pre-gyp-fix.js
+++ b/src/node-pre-gyp-fix.js
@@ -1,0 +1,65 @@
+import os from 'os';
+import path from 'path';
+import spawn from './spawn.js';
+import promisify from './promisify.js';
+const glob = promisify(require('glob'));
+const cp = promisify(require('ncp').ncp);
+
+async function link(from, to, cwd) {
+  let cmd;
+  let args;
+
+  if (from === to) return;
+
+  if (os.platform() === 'win32') {
+    cmd = 'mklink';
+    args = ['/D', to, from];
+  } else {
+    cmd = 'ln';
+    args = ['-nsf', from, to];
+  }
+
+  try {
+    return await spawn({cmd, args, cwd});
+  } catch (e) {
+    if (e.stdout) console.log(e.stdout);
+    if (e.stderr) console.log(e.stderr);
+
+    throw e;
+  }
+}
+
+async function findNativeModules(cwd, runtime) {
+  let mapReadyPaths = {};
+  let pathArray = await glob(path.join(cwd, 'node_modules', '**', runtime+'-v*'))
+
+  pathArray.forEach(item => {
+    item = item.split(path.sep);
+
+    let val = item.pop();
+    mapReadyPaths[path.join(...item)] = path.join(cwd, ...item, val);
+  })
+
+  return mapReadyPaths;
+}
+
+var pathsBeforeRebuild;
+
+export async function preGypFixSetup(cwd) {
+  return pathsBeforeRebuild = await findNativeModules(cwd, 'node');
+}
+
+export async function preGypFixRun(cwd) {
+  if (!pathsBeforeRebuild) return;
+
+  let pathsAfterRebuild = await findNativeModules(cwd, 'electron');
+
+  for(let key in pathsBeforeRebuild) {
+    if (!pathsBeforeRebuild.hasOwnProperty(key) || !pathsAfterRebuild.hasOwnProperty(key)) {
+      console.log('node-pre-gyp paths not fixed for', key, '- unexpected behaviour ocurred');
+      continue;
+    }
+
+    await cp(pathsAfterRebuild[key], pathsBeforeRebuild[key]);
+  }
+}

--- a/src/node-pre-gyp-fix.js
+++ b/src/node-pre-gyp-fix.js
@@ -1,65 +1,21 @@
-import os from 'os';
 import path from 'path';
 import spawn from './spawn.js';
 import promisify from './promisify.js';
+import {getElectronModuleVersion} from './main.js';
 const glob = promisify(require('glob'));
 const cp = promisify(require('ncp').ncp);
 
-async function link(from, to, cwd) {
-  let cmd;
-  let args;
+export async function preGypFixRun(cwd, shouldRun, electronPath, explicitNodeVersion=null) {
+  if (!shouldRun) return;
 
-  if (from === to) return;
+  let paths = await glob(path.join(cwd, '**', 'electron-v*'));
+  let electronModuleVersion = explicitNodeVersion || (await getElectronModuleVersion(electronPath));
 
-  if (os.platform() === 'win32') {
-    cmd = 'mklink';
-    args = ['/D', to, from];
-  } else {
-    cmd = 'ln';
-    args = ['-nsf', from, to];
-  }
+  for(let path of paths) {
+    // THE MIGHTY HACK GOES HERE!
+    let newPath = path.replace(/electron-v[^-]+/, 'node-v'+electronModuleVersion);
 
-  try {
-    return await spawn({cmd, args, cwd});
-  } catch (e) {
-    if (e.stdout) console.log(e.stdout);
-    if (e.stderr) console.log(e.stderr);
-
-    throw e;
-  }
-}
-
-async function findNativeModules(cwd, runtime) {
-  let mapReadyPaths = {};
-  let pathArray = await glob(path.join(cwd, 'node_modules', '**', runtime+'-v*'))
-
-  pathArray.forEach(item => {
-    item = item.split(path.sep);
-
-    let val = item.pop();
-    mapReadyPaths[path.join(...item)] = path.join(cwd, ...item, val);
-  })
-
-  return mapReadyPaths;
-}
-
-var pathsBeforeRebuild;
-
-export async function preGypFixSetup(cwd) {
-  return pathsBeforeRebuild = await findNativeModules(cwd, 'node');
-}
-
-export async function preGypFixRun(cwd) {
-  if (!pathsBeforeRebuild) return;
-
-  let pathsAfterRebuild = await findNativeModules(cwd, 'electron');
-
-  for(let key in pathsBeforeRebuild) {
-    if (!pathsBeforeRebuild.hasOwnProperty(key) || !pathsAfterRebuild.hasOwnProperty(key)) {
-      console.log('node-pre-gyp paths not fixed for', key, '- unexpected behaviour ocurred');
-      continue;
-    }
-
-    await cp(pathsAfterRebuild[key], pathsBeforeRebuild[key]);
+    await cp(path, newPath);
+    console.log('node-pre-gyp fixer:', path, 'copied to', newPath)
   }
 }


### PR DESCRIPTION
[node-pre-gyp](https://www.npmjs.com/package/node-pre-gyp) is used by some popular projects (like [serialport](https://www.npmjs.com/package/serialport)) to provide precompiled binaries to most users. In electron's case it falls back to compilation and does so successfully.
Unfortunately, node-pre-gyp doesn't detect electron during runtime and tries to load native addons through the "normal" node path (...../node-v1234-os-arch.... instead of electron-v1234-os-arch).
Some pull requests have been submitted that fix the issue: mapbox/node-pre-gyp#177 and mapbox/node-pre-gyp#187 but they have been open for some months without any activity.

So I created a command-line switch (-p or --pre-gyp-fix) that copies the bindings' folder to the path current node-pre-gyp versions expect it to be in, when a fix is released in node-pre-gyp compatibility should not be broken and, since it's disabled by default it won't break anything to those not using it.

While developing this patch I noticed a couple of things
- electronPath in src/cli.js is defined without taking into account the path where electron-prebuilt resides, generating an ENOENT whenever getElectronModuleVersion() is called
- Calling toString(versionAsString) at the end of getElectronModuleVersion() turns the version string (it is returned as a string already) into a useless weird object

...so I fixed them in the process! :)