### PR TITLE
Document the node-pre-gyp workaround and make it easier to invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,23 @@ shouldRebuildNativeModules(pathToElectron)
     console.error(e);
   });
 ```
+
+### `node-pre-gyp` workaround
+
+Note that there is a known [issue](https://github.com/mapbox/node-pre-gyp/pull/187) with
+`node-pre-gyp` that prevents it from correctly locating the native modules built by
+`electron-rebuild`. `node-pre-gyp` is used by some popular NPM packages like `sqlite3`,
+and `node-inspector`, so even if your app or package does not have a direct dependency on
+`node-pre-gyp` you're bound to run into this issue sooner or later. To work around it call
+`preGypFixRun` after the build is complete in order to copy the native modules to a location
+where `node-pre-gyp` can find them:
+
+```js
+import { preGypFixRun } from 'electron-rebuild';
+
+return installNodeHeaders('v0.27.2')
+  .then(() => rebuildNativeModules('v0.27.2', './node_modules'))
+  .then(() => preGypFixRun('./node_modules', true, pathToElectron));
+``` 
+
+If you're using the CLI to perform the build then use the `-p` or `--pre-gyp-fix` option.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import {installNodeHeaders, rebuildNativeModules, shouldRebuildNativeModules} from './main.js';
-import { preGypFixSetup, preGypFixRun } from './node-pre-gyp-fix.js'
+import { preGypFixRun } from './node-pre-gyp-fix.js'
 import path from 'path';
 import fs from 'fs';
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import childProcess from 'child_process';
 import spawn from './spawn';
 import promisify from './promisify';
+export { preGypFixRun } from './node-pre-gyp-fix';
 
 const fs = promisify(require('fs'));
 


### PR DESCRIPTION
Re-export the `preGypFixRun` function from `main.js` so it's easier to import from the outside.